### PR TITLE
Fix typo in ACL

### DIFF
--- a/docs/project/guides/mqtt-authentication.md
+++ b/docs/project/guides/mqtt-authentication.md
@@ -62,7 +62,7 @@ user chirpstack_gw
 topic write gateway/+/event/+
 topic read gateway/+/command/+
 
-user chirpstackns
+user chirpstack_ns
 topic read gateway/+/event/+
 topic write gateway/+/command/+
 


### PR DESCRIPTION
Fix the network server name in ACL to match user from the password file.